### PR TITLE
DBZ-3027 - Remove POC references from UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This project is under active development, any contributions are very welcome.
 
 ## Prerequisites
 
-Debezium UI needs a properly running Debezium instance version 1.4.0.Beta1 or newer and a running
-Postgres or Mongo DB database instance (depending on what connector you are going to use).
+Debezium UI needs a properly running Debezium instance version 1.4.0.Beta1 or newer and running DB instances, depending
+on what connectors you are going to use (Postgres, Mongo DB, MySQL, etc).
 
 ### DEV Infrastructure with Docker-Compose
 
@@ -90,7 +90,7 @@ whose contents are then exposed by the Quarkus-based backend application.
 
 ### UI Development
 
-The UI code for is located in the _ui_ folder, with README instructions
+The UI code is located in the _ui_ folder, with README instructions
 [here](./ui/README.md) to launch the UI for development.
 
 ### Backend

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.debezium.ui</groupId>
+    <groupId>io.debezium</groupId>
     <artifactId>debezium-ui-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -3,12 +3,12 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>io.debezium.uipoc</groupId>
-    <artifactId>debezium-uipoc-parent</artifactId>
+    <groupId>io.debezium.ui</groupId>
+    <artifactId>debezium-ui-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
   </parent>
-  <artifactId>debezium-uipoc-backend</artifactId>
-  <name>Debezium UI PoC Backend</name>
+  <artifactId>debezium-ui-backend</artifactId>
+  <name>Debezium UI Backend</name>
 
   <properties>
     <logmanager.class>org.jboss.logmanager.LogManager</logmanager.class>
@@ -156,7 +156,7 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>${project.groupId}</groupId>
-                  <artifactId>debezium-uipoc-frontend</artifactId>
+                  <artifactId>debezium-ui-frontend</artifactId>
                   <version>${project.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>

--- a/oc-demo/05-ui.yaml
+++ b/oc-demo/05-ui.yaml
@@ -37,7 +37,7 @@ spec:
     spec:
       containers:
       - name: dbzui-service
-        image: debezium/debezium-ui-poc:latest
+        image: debezium/debezium-ui:latest
         imagePullPolicy: Always
         envFrom:
         - configMapRef:

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.debezium.uipoc</groupId>
-  <artifactId>debezium-uipoc-parent</artifactId>
+  <groupId>io.debezium.ui</groupId>
+  <artifactId>debezium-ui-parent</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  <name>Debezium UI PoC Build Aggregator</name>
+  <name>Debezium UI Build Aggregator</name>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.debezium.ui</groupId>
+  <groupId>io.debezium</groupId>
   <artifactId>debezium-ui-parent</artifactId>
   <version>1.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
 
 
-# Debezium UI POC
+# Debezium UI
 
 React-based Single Page Application based on Patternfly 4
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
-  "description": "Debezium UI POC",
-  "repository": "https://github.com/debezium/debezium-ui-poc.git",
+  "description": "Debezium UI",
+  "repository": "https://github.com/debezium/debezium-ui.git",
   "license": "Apache-2.0",
   "private": true,
   "workspaces": {
@@ -32,5 +32,5 @@
     "husky": "^4.3.7",
     "lerna": "3.21.0"
   },
-  "name": "debezium-ui-poc"
+  "name": "debezium-ui"
 }

--- a/ui/packages/ui/package.json
+++ b/ui/packages/ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "description": "Debezium UI",
   "main": "index.js",
-  "repository": "https://github.com/debezium/debezium-ui-poc.git",
+  "repository": "https://github.com/debezium/debezium-ui.git",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {

--- a/ui/packages/ui/webpack.common.js
+++ b/ui/packages/ui/webpack.common.js
@@ -21,7 +21,7 @@ module.exports = {
       'process.env.ASSET_PATH': JSON.stringify(ASSET_PATH),
     }),
     new webpack.container.ModuleFederationPlugin({
-      name: 'debeziumuipoc',
+      name: 'debeziumui',
       filename: "remoteEntry.js",
       exposes: {
         "./debeziumCreateConnector": "./src/app/pages/createConnector/CreateConnectorComponent",

--- a/ui/packages/ui/webpack.dev.js
+++ b/ui/packages/ui/webpack.dev.js
@@ -15,7 +15,7 @@ module.exports = merge(common, {
   ],
   output: {
     publicPath: (false && isProd && remoteSuffix)
-      ? `http://debeziumuipoc${remoteSuffix}/`
+      ? `http://debeziumui${remoteSuffix}/`
       : `http://localhost:8888/`
   },
   devServer: {

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.debezium.ui</groupId>
+    <groupId>io.debezium</groupId>
     <artifactId>debezium-ui-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -6,15 +6,15 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>io.debezium.uipoc</groupId>
-    <artifactId>debezium-uipoc-parent</artifactId>
+    <groupId>io.debezium.ui</groupId>
+    <artifactId>debezium-ui-parent</artifactId>
     <version>1.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>debezium-uipoc-frontend</artifactId>
+  <artifactId>debezium-ui-frontend</artifactId>
   <packaging>jar</packaging>
-  <name>Debezium UI PoC Frontend</name>
+  <name>Debezium UI Frontend</name>
 
   <properties>
     <!-- UI Build Tools -->


### PR DESCRIPTION
Initial changes for removing POC references.  The repo name will need to be changed to 'debezium-ui'.  Also the dockerhub image 'debezium-ui-poc'