### PR TITLE
DBZ-3255 & DBZ-3314

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -2,8 +2,8 @@ quarkus.http.cors=true
 quarkus.http.test-port=0
 quarkus.http.test-ssl-port=0
 
-# ui.base.uri=http://localhost:8080/api
-# deployment.mode=validation.disabled
+ui.base.uri=http://localhost:8080/api
+deployment.mode=validation.disabled
 
 ## Test Env Configuration
 %test.quarkus.log.category."org.testcontainers".level=WARN

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -2,8 +2,8 @@ quarkus.http.cors=true
 quarkus.http.test-port=0
 quarkus.http.test-ssl-port=0
 
-ui.base.uri=http://localhost:8080/api
-deployment.mode=validation.disabled
+# ui.base.uri=http://localhost:8080/api
+# deployment.mode=validation.disabled
 
 ## Test Env Configuration
 %test.quarkus.log.category."org.testcontainers".level=WARN

--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -118,6 +118,7 @@ export interface ConnectorType {
     displayName: string;
     version: string;
     enabled: boolean;
+    // TODO: Need to be removed as when backend updates.
     properties: ConnectorProperty[];
 }
 

--- a/ui/packages/services/src/connector/connector.service.ts
+++ b/ui/packages/services/src/connector/connector.service.ts
@@ -15,13 +15,32 @@
  * limitations under the License.
  */
 
-import { ConnectionValidationResult, Connector, FilterValidationResult, PropertiesValidationResult } from "@debezium/ui-models";
+import { ConnectionValidationResult, Connector, ConnectorType, FilterValidationResult, PropertiesValidationResult } from "@debezium/ui-models";
 import { BaseService } from "../baseService";
 
 /**
  * The connector service.  Used to fetch connectors and other connector operations.
  */
 export class ConnectorService extends BaseService {
+
+    /**
+     * Get the details of connector for supplied connection type
+     * Example usage:
+     * 
+     * const connectorService = Services.getConnectorService();
+     * connectorService.getConnectorInfo('postgres')
+     *  .then((cDetails: ConnectorType) => {
+     *      alert(cDetails);
+     *  })
+     * .catch((err: Error) => {
+     *      alert(err);
+     *  });
+     */
+    public getConnectorInfo(connectorTypeId: string): Promise<ConnectorType> {
+        this.logger.info("[ConnectorService] Getting the details of Connector:", connectorTypeId);
+        const endpoint: string = this.endpoint("/connector-types/:connectorTypeId", { connectorTypeId });
+        return this.httpGet<ConnectorType>(endpoint);
+    }
 
     /**
      * Validate the connection properties for the supplied connection type

--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FilterConfigComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/FilterConfigComponent.tsx
@@ -124,7 +124,6 @@ export const FilterConfigComponent: React.FunctionComponent<IFilterConfigCompone
           setTreeData([]);
           setChildNo(result.matchedCollections.length);
         } else {
-          // tslint:disable-next-line: no-unused-expression
           saveFilter && props.updateFilterValues(filterExpression);
           props.setIsValidFilter(true);
           setInvalidMsg(new Map());

--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/CreateConnectorNoValidation.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/CreateConnectorNoValidation.tsx
@@ -240,28 +240,33 @@ export const CreateConnectorNoValidation: React.FunctionComponent<ICreateConnect
 
   const onFinish = () => {
     // Cluster ID and connector name for the create
-    const clusterID = props.clusterId;
-    const connectorName = basicPropValues.get(PropertyName.CONNECTOR_NAME);
+    
+    // TODO: Commenting it for time being as required to remove all the backend call from UI  in no-validation mode
 
-    const finalProperties = getFinalProperties(finishStepId);
+    // const clusterID = props.clusterId;
+    // const connectorName = basicPropValues.get(PropertyName.CONNECTOR_NAME);
 
-    const connectorService = Services.getConnectorService();
-    fetch_retry(connectorService.createConnector, connectorService, [
-      clusterID,
-      selectedConnectorType,
-      {
-        name: connectorName,
-        config: mapToObject(finalProperties),
-      },
-    ])
-      .then(() => {
-        // On success, redirect to connectors page
-        props.onSuccessCallback();
-      })
-      .catch((err: Error) => {
-        setConnectorCreateFailed(true);
-        addAlert(err?.message);
-      });
+    // const finalProperties = getFinalProperties(finishStepId);
+
+    // const connectorService = Services.getConnectorService();
+
+    // fetch_retry(connectorService.createConnector, connectorService, [
+    //   clusterID,
+    //   selectedConnectorType,
+    //   {
+    //     name: connectorName,
+    //     config: mapToObject(finalProperties),
+    //   },
+    // ])
+    //   .then(() => {
+    //     // On success, redirect to connectors page
+    //     props.onSuccessCallback();
+    //   })
+    //   .catch((err: Error) => {
+    //     setConnectorCreateFailed(true);
+    //     addAlert(err?.message);
+    //   });
+      props.onSuccessCallback();
   };
 
   const doCancelConfirmed = () => {

--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/CreateConnectorNoValidation.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/CreateConnectorNoValidation.tsx
@@ -280,7 +280,6 @@ export const CreateConnectorNoValidation: React.FunctionComponent<ICreateConnect
 
   const goToNext = (id: any, onNext: () => void) => {
     setConnectorCreateFailed(false);
-    // tslint:disable-next-line: no-unused-expression
     id === 5 && setFinishStepId(RUNTIME_OPTIONS_STEP_ID);
     setStepIdReached(stepIdReached < id ? id : stepIdReached);
     validateStep(id, onNext);
@@ -322,20 +321,31 @@ export const CreateConnectorNoValidation: React.FunctionComponent<ICreateConnect
   const onConnectorTypeChanged = (cType: string | undefined): void => {
     setSelectedConnectorType(cType);
     if (cType) {
-      const connType = connectorTypes.find((conn) => conn.id === cType);
+      const connectorService = Services.getConnectorService();
+      fetch_retry(connectorService.getConnectorInfo, connectorService, [cType])
+        .then((cDetails: ConnectorType) => {
+          setLoading(false);
 
-      if (
-        connType?.properties.find(
-          (obj) => obj?.name === "column.mask.hash.([^.]+).with.salt.(.+)"
-        )?.name
-      ) {
-        connType.properties.find(
-          (obj) => obj?.name === "column.mask.hash.([^.]+).with.salt.(.+)"
-        ).name = "column.mask.hash";
-      }
-      setSelectedConnectorPropertyDefns(
-        getFormattedProperties(connType!.properties, connType)
-      );
+          // TODO: Find the solution to this issue.
+          if (
+            cDetails?.properties.find(
+              (obj: { name: string }) =>
+                obj?.name === "column.mask.hash.([^.]+).with.salt.(.+)"
+            )?.name
+          ) {
+            cDetails.properties.find(
+              (obj: { name: string }) =>
+                obj?.name === "column.mask.hash.([^.]+).with.salt.(.+)"
+            ).name = "column.mask.hash";
+          }
+          setSelectedConnectorPropertyDefns(
+            getFormattedProperties(cDetails.properties, cDetails)
+          );
+        })
+        .catch((err: React.SetStateAction<Error>) => {
+          setApiError(true);
+          setErrorMsg(err);
+        });
       initPropertyValues();
     }
     setConnectionPropsValidMsg([]);
@@ -416,28 +426,36 @@ export const CreateConnectorNoValidation: React.FunctionComponent<ICreateConnect
 
   // Init the selected connector type to first 'enabled' connectortype
   React.useEffect(() => {
-    // tslint:disable-next-line: no-unused-expression
-    connectorTypes[0]?.id && setSelectedConnectorType(connectorTypes[0].id);
+    if (connectorTypes.length !== 0) {
+      connectorTypes[0]?.id && setSelectedConnectorType(connectorTypes[0].id);
 
-    if (
-      connectorTypes[0]?.properties.find(
-        (obj) => obj.name === "column.mask.hash.([^.]+).with.salt.(.+)"
-      )?.name
-    ) {
-      connectorTypes[0].properties.find(
-        (obj) => obj.name === "column.mask.hash.([^.]+).with.salt.(.+)"
-      ).name = "column.mask.hash";
+      const connectorService = Services.getConnectorService();
+      fetch_retry(connectorService.getConnectorInfo, connectorService, [
+        connectorTypes[0]?.id,
+      ])
+        .then((cDetails: ConnectorType) => {
+          setLoading(false);
+          // TODO: Find the solution to this issue.
+          if (
+            cDetails?.properties.find(
+              (obj: { name: string }) =>
+                obj.name === "column.mask.hash.([^.]+).with.salt.(.+)"
+            )?.name
+          ) {
+            cDetails.properties.find(
+              (obj: { name: string }) =>
+                obj.name === "column.mask.hash.([^.]+).with.salt.(.+)"
+            ).name = "column.mask.hash";
+          }
+          setSelectedConnectorPropertyDefns(
+            getFormattedProperties(cDetails.properties, cDetails)
+          );
+        })
+        .catch((err: React.SetStateAction<Error>) => {
+          setApiError(true);
+          setErrorMsg(err);
+        });
     }
-
-    // tslint:disable-next-line: no-unused-expression
-    connectorTypes[0]?.properties &&
-      setSelectedConnectorPropertyDefns(
-        getFormattedProperties(
-          connectorTypes[0]!.properties,
-          connectorTypes[0]!
-        )
-      );
-
     // Init the connector property values
     initPropertyValues();
   }, [connectorTypes]);

--- a/ui/packages/ui/tslint.json
+++ b/ui/packages/ui/tslint.json
@@ -7,6 +7,7 @@
   },
   "rules": {
     "jsx-no-lambda": false,
-    "object-literal-sort-keys": false
+    "object-literal-sort-keys": false,
+    "no-unused-expression":  [true, "allow-fast-null-checks"]
   }
 }


### PR DESCRIPTION
Jira issue [DBZ-3314](https://issues.redhat.com/browse/DBZ-3314)  [DBZ-3255](https://issues.redhat.com/browse/DBZ-3255)
- Removed the `/connector/{cluster}/{connector-id})` call from the no-validation mode
- Updated the API end points for `/connector-types` with `/connector-types` only being used to get the connector basic info (name, if) and `/connector-types/{connector-type}` to get the passed connector propertie details. 