### PR TITLE
DBZ-3316 Remove properties from connector-types response

### DIFF
--- a/backend/src/main/java/io/debezium/configserver/model/ConnectorDefinition.java
+++ b/backend/src/main/java/io/debezium/configserver/model/ConnectorDefinition.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Debezium Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.debezium.configserver.model;
+
+public class ConnectorDefinition {
+
+    public String id;
+    public String className;
+    public String displayName;
+    public String version;
+    public boolean enabled;
+
+    public ConnectorDefinition() {
+    }
+
+    public ConnectorDefinition(String id, String className, String displayName, String version, boolean enabled) {
+        this.id = id;
+        this.className = className;
+        this.displayName = displayName;
+        this.version = version;
+        this.enabled = enabled;
+    }
+
+}

--- a/backend/src/main/java/io/debezium/configserver/model/ConnectorType.java
+++ b/backend/src/main/java/io/debezium/configserver/model/ConnectorType.java
@@ -7,24 +7,15 @@ package io.debezium.configserver.model;
 
 import java.util.List;
 
-public class ConnectorType {
+public class ConnectorType extends ConnectorDefinition {
 
-    public String id;
-    public String className;
-    public String displayName;
-    public String version;
-    public boolean enabled;
     public List<ConnectorProperty> properties;
 
     public ConnectorType() {
     }
 
     public ConnectorType(String id, String className, String displayName, String version, boolean enabled, List<ConnectorProperty> properties) {
-        this.id = id;
-        this.className = className;
-        this.displayName = displayName;
-        this.version = version;
-        this.enabled = enabled;
+        super(id, className, displayName, version, enabled);
         this.properties = properties;
     }
 }

--- a/backend/src/main/java/io/debezium/configserver/service/ConnectorIntegrator.java
+++ b/backend/src/main/java/io/debezium/configserver/service/ConnectorIntegrator.java
@@ -10,13 +10,16 @@ import java.util.Map;
 import io.debezium.config.Field;
 import io.debezium.configserver.model.AdditionalPropertyMetadata;
 import io.debezium.configserver.model.ConnectionValidationResult;
+import io.debezium.configserver.model.ConnectorDefinition;
 import io.debezium.configserver.model.ConnectorType;
 import io.debezium.configserver.model.FilterValidationResult;
 import io.debezium.configserver.model.PropertiesValidationResult;
 
 public interface ConnectorIntegrator {
 
-    ConnectorType getDescriptor();
+    ConnectorType getConnectorType();
+
+    ConnectorDefinition getConnectorDefinition();
 
     Map<String, AdditionalPropertyMetadata> allPropertiesWithAdditionalMetadata();
 

--- a/backend/src/main/java/io/debezium/configserver/service/ConnectorIntegratorBase.java
+++ b/backend/src/main/java/io/debezium/configserver/service/ConnectorIntegratorBase.java
@@ -23,6 +23,7 @@ import org.apache.kafka.connect.source.SourceConnector;
 import io.debezium.config.Configuration;
 import io.debezium.config.Field;
 import io.debezium.configserver.model.ConnectionValidationResult;
+import io.debezium.configserver.model.ConnectorDefinition;
 import io.debezium.configserver.model.ConnectorProperty;
 import io.debezium.configserver.model.ConnectorType;
 import io.debezium.configserver.model.GenericValidationResult;
@@ -51,7 +52,21 @@ public abstract class ConnectorIntegratorBase implements ConnectorIntegrator {
     }
 
     @Override
-    public ConnectorType getDescriptor() {
+    public ConnectorDefinition getConnectorDefinition() {
+        ConnectorDescriptor descriptor = getConnectorDescriptor();
+        SourceConnector instance = getConnector();
+
+        return new ConnectorDefinition(
+            descriptor.id,
+            instance.getClass().getName(),
+            descriptor.name,
+            instance.version(),
+            descriptor.enabled
+        );
+    }
+
+    @Override
+    public ConnectorType getConnectorType() {
         ConnectorDescriptor descriptor = getConnectorDescriptor();
         SourceConnector instance = getConnector();
 

--- a/ui/packages/models/src/ui.model.ts
+++ b/ui/packages/models/src/ui.model.ts
@@ -109,7 +109,7 @@ export interface ConnectorProperty {
 }
 
 /**
- * Model which represents a connectory type
+ * Model which represents a connector type
  */
 // tslint:disable-next-line: interface-name
 export interface ConnectorType {
@@ -118,8 +118,7 @@ export interface ConnectorType {
     displayName: string;
     version: string;
     enabled: boolean;
-    // TODO: Need to be removed as when backend updates.
-    properties: ConnectorProperty[];
+    properties?: ConnectorProperty[];
 }
 
 /**


### PR DESCRIPTION
backend:
connector-types - removes properties from the response
connector-types/{id} - now only returns the array of properties

ui:
remove properties attribute from the ConnectorType model
adjust the service and usages to account for the connector-types/{id} only returning properties array