### PR TITLE
Fix required property messages; other minor fixes

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/CreateConnectorNoValidation.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/CreateConnectorNoValidation.tsx
@@ -32,7 +32,6 @@ import {
   getRuntimeOptionsPropertyDefinitions,
   isDataOptions,
   isRuntimeOptions,
-  mapToObject,
   minimizePropertyValues,
   PropertyCategory,
   PropertyName,
@@ -532,7 +531,6 @@ export const CreateConnectorNoValidation: React.FunctionComponent<ICreateConnect
               updateFilterValues={handleFilterUpdate}
               connectorType={selectedConnectorType || ""}
               setIsValidFilter={setIsValidFilter}
-              selectedConnectorType={selectedConnectorType || ""}
             />
           </>
         ),

--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/connectorSteps/FilterConfigNoValidationStep.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/connectorSteps/FilterConfigNoValidationStep.tsx
@@ -25,7 +25,6 @@ export interface IFilterConfigNoValidationStepProps {
   connectorType: string;
   updateFilterValues: (data: Map<string, string>) => void;
   setIsValidFilter: (val: SetStateAction<boolean>) => void;
-  selectedConnectorType: string;
 }
 
 export const FilterConfigNoValidationStep: React.FunctionComponent<IFilterConfigNoValidationStepProps> = (
@@ -67,7 +66,7 @@ export const FilterConfigNoValidationStep: React.FunctionComponent<IFilterConfig
   }, [formData]);
 
   const filterConfigurationPageContentObj: any = getFilterConfigurationPageContent(
-    props.selectedConnectorType || ""
+    props.connectorType || ""
   );
 
   return (

--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/DataOptions.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/DataOptions.tsx
@@ -16,7 +16,7 @@ import "./DataOption.css";
 
 export interface IDataOptionsProps {
   connectorName: string;
-  selectedConnector: string;
+  connectorType: string;
   configuration: Map<string, unknown>;
   propertyDefinitions: ConnectorProperty[];
   i18nAdvancedMappingPropertiesText: string;
@@ -144,7 +144,7 @@ export const DataOptions: React.FC<IDataOptionsProps> = (props) => {
     <div style={{ padding: "20px" }} className={"data-options-component-page"}>
       <ConnectorNameTypeHeader
         connectorName={props.connectorName}
-        connectorType={"postgres"}
+        connectorType={props.connectorType}
         showIcon={false}
       />
       <Formik
@@ -186,7 +186,6 @@ export const DataOptions: React.FC<IDataOptionsProps> = (props) => {
                                 propertyDefinition={propertyDefinition}
                                 propertyChange={handlePropertyChange}
                                 setFieldValue={setFieldValue}
-                                helperTextInvalid={"ipsomlorem"}
                                 invalidMsg={[]}
                                 validated={"default"}
                               />
@@ -220,7 +219,6 @@ export const DataOptions: React.FC<IDataOptionsProps> = (props) => {
                                 propertyDefinition={propertyDefinition}
                                 propertyChange={handlePropertyChange}
                                 setFieldValue={setFieldValue}
-                                helperTextInvalid={"ipsomlorem"}
                                 invalidMsg={[]}
                                 validated={"default"}
                               />
@@ -250,7 +248,6 @@ export const DataOptions: React.FC<IDataOptionsProps> = (props) => {
                                 propertyDefinition={propertyDefinition}
                                 propertyChange={handlePropertyChange}
                                 setFieldValue={setFieldValue}
-                                helperTextInvalid={"ipsomlorem"}
                                 invalidMsg={[]}
                                 validated={"default"}
                               />

--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/DebeziumConfigurator.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/DebeziumConfigurator.tsx
@@ -229,7 +229,7 @@ export const DebeziumConfigurator: React.FC<IDebeziumConfiguratorProps> = (
       case PROPERTIES_STEP_ID:
         return (
           <Properties
-            selectedConnector={props.connector.name}
+            connectorType={PostgresData.json_schema["x-connector-id"]}
             configuration={props.configuration}
             onChange={(conf: Map<string, unknown>, status: boolean) =>
               props.onChange(conf, status)
@@ -257,9 +257,8 @@ export const DebeziumConfigurator: React.FC<IDebeziumConfiguratorProps> = (
             <FilterConfigNoValidationStep
               filterValues={filterValues}
               updateFilterValues={handleFilterUpdate}
-              connectorType={""}
+              connectorType={PostgresData.json_schema["x-connector-id"]}
               setIsValidFilter={setIsValidFilter}
-              selectedConnectorType={""}
             />
           </div>
         );
@@ -269,7 +268,7 @@ export const DebeziumConfigurator: React.FC<IDebeziumConfiguratorProps> = (
             connectorName={
               (props.configuration?.get("connector_name") as string) || ""
             }
-            selectedConnector={props.connector.name}
+            connectorType={PostgresData.json_schema["x-connector-id"]}
             configuration={props.configuration}
             onChange={(conf: Map<string, unknown>, status: boolean) =>
               props.onChange(conf, status)
@@ -290,7 +289,7 @@ export const DebeziumConfigurator: React.FC<IDebeziumConfiguratorProps> = (
             connectorName={
               (props.configuration?.get("connector_name") as string) || ""
             }
-            selectedConnector={props.connector.name}
+            connectorType={PostgresData.json_schema["x-connector-id"]}
             configuration={props.configuration}
             onChange={(conf: Map<string, unknown>, status: boolean) =>
               props.onChange(conf, status)

--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/Properties.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/Properties.tsx
@@ -22,7 +22,7 @@ import "./Properties.css";
 
 
 export interface IPropertiesProps {
-  selectedConnector: string;
+  connectorType: string;
   configuration: Map<string, unknown>;
   propertyDefinitions: ConnectorProperty[];
   i18nAdvancedPropertiesText: string;
@@ -56,7 +56,7 @@ const setValidation = (values: any, propertyList: ConnectorProperty[]) => {
 
   propertyList.forEach((property) => {
     if (property.isMandatory && !values[property.name.replace(/[.]/g, "_")]) {
-      errors[property.name.replace(/[.]/g, "_")] = "Required";
+      errors[property.name.replace(/[.]/g, "_")] = `${property.displayName} is required`;
     }
   });
   return errors;
@@ -190,7 +190,7 @@ export const Properties: React.FC<IPropertiesProps> = (props) => {
                           propertyDefinition={propertyDefinition}
                           propertyChange={handlePropertyChange}
                           setFieldValue={setFieldValue}
-                          helperTextInvalid={"ipsomlorem"}
+                          helperTextInvalid={errors[propertyDefinition.name]}
                           invalidMsg={[]}
                           validated={
                             errors[
@@ -218,8 +218,7 @@ export const Properties: React.FC<IPropertiesProps> = (props) => {
                     </SplitItem>
                     <SplitItem>
                       <ConnectorTypeComponent
-                        // connectorType={props.selectedConnector} PostgreSQL
-                        connectorType={"postgres"}
+                        connectorType={props.connectorType}
                         showIcon={false}
                       />
                     </SplitItem>
@@ -255,7 +254,7 @@ export const Properties: React.FC<IPropertiesProps> = (props) => {
                                   propertyDefinition={propertyDefinition}
                                   propertyChange={handlePropertyChange}
                                   setFieldValue={setFieldValue}
-                                  helperTextInvalid={"ipsomlorem"}
+                                  helperTextInvalid={errors[propertyDefinition.name]}
                                   invalidMsg={[]}
                                   validated={
                                     errors[
@@ -307,7 +306,7 @@ export const Properties: React.FC<IPropertiesProps> = (props) => {
                                     propertyDefinition={propertyDefinition}
                                     propertyChange={handlePropertyChange}
                                     setFieldValue={setFieldValue}
-                                    helperTextInvalid={"ipsomlorem"}
+                                    helperTextInvalid={errors[propertyDefinition.name]}
                                     invalidMsg={[]}
                                     validated={
                                       errors[
@@ -358,7 +357,7 @@ export const Properties: React.FC<IPropertiesProps> = (props) => {
                                     propertyDefinition={propertyDefinition}
                                     propertyChange={handlePropertyChange}
                                     setFieldValue={setFieldValue}
-                                    helperTextInvalid={"ipsomlorem"}
+                                    helperTextInvalid={errors[propertyDefinition.name]}
                                     invalidMsg={[]}
                                     validated={
                                       errors[
@@ -413,7 +412,7 @@ export const Properties: React.FC<IPropertiesProps> = (props) => {
                                         propertyDefinition={propertyDefinition}
                                         propertyChange={handlePropertyChange}
                                         setFieldValue={setFieldValue}
-                                        helperTextInvalid={"ipsomlorem"}
+                                        helperTextInvalid={errors[propertyDefinition.name]}
                                         invalidMsg={[]}
                                         validated={
                                           errors[

--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/RuntimeOptions.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/RuntimeOptions.tsx
@@ -15,7 +15,7 @@ import "./RuntimeOptions.css";
 
 export interface IRuntimeOptionsProps {
   connectorName: string;
-  selectedConnector: string;
+  connectorType: string;
   configuration: Map<string, unknown>;
   propertyDefinitions: ConnectorProperty[];
   i18nEngineProperties: string;
@@ -144,7 +144,7 @@ export const RuntimeOptions: React.FC<IRuntimeOptionsProps> = (props) => {
     >
       <ConnectorNameTypeHeader
         connectorName={props.connectorName}
-        connectorType={"postgres"}
+        connectorType={props.connectorType}
         showIcon={false}
       />
       <Formik
@@ -184,7 +184,6 @@ export const RuntimeOptions: React.FC<IRuntimeOptionsProps> = (props) => {
                                 propertyDefinition={propertyDefinition}
                                 propertyChange={handlePropertyChange}
                                 setFieldValue={setFieldValue}
-                                helperTextInvalid={"ipsomlorem"}
                                 invalidMsg={[]}
                                 validated={"default"}
                               />
@@ -218,7 +217,6 @@ export const RuntimeOptions: React.FC<IRuntimeOptionsProps> = (props) => {
                                 propertyDefinition={propertyDefinition}
                                 propertyChange={handlePropertyChange}
                                 setFieldValue={setFieldValue}
-                                helperTextInvalid={"ipsomlorem"}
                                 invalidMsg={[]}
                                 validated={"default"}
                               />

--- a/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/config.ts
+++ b/ui/packages/ui/src/app/pages/createConnector/noValidation/debezium/config.ts
@@ -2,7 +2,7 @@
 import { DebeziumConfigurator } from './DebeziumConfigurator';
 
 const config = {
-  steps: ["Properties step", "Filter step", "Data option", "Runtime option"],
+  steps: ["Properties", "Filter definition", "Data options", "Runtime options"],
   Configurator: DebeziumConfigurator
 };
 


### PR DESCRIPTION
- for the required properties, changed the message to include property name - same as standalone
- replaced hardcoded invalid message
- renamed some component properties for connectorType
- DebeziumConfigurator passes connectorType into steps (still hardcoded to the postgres schema)
- removed some unused component properties
- name configurator steps to match standalone app