### PR TITLE
DBZ-3580 - handle nulls in connectors response

### DIFF
--- a/ui/packages/ui/src/app/pages/connectors/ConnectorsTableComponent.tsx
+++ b/ui/packages/ui/src/app/pages/connectors/ConnectorsTableComponent.tsx
@@ -196,7 +196,7 @@ export const ConnectorsTableComponent: React.FunctionComponent<IConnectorsTableC
     ])
       .then((cConnectors: Connector[]) => {
         setLoading(false);
-        setConnectors(cConnectors);
+        setConnectors(cConnectors.filter(c => c !== null));
       })
       .catch((err: React.SetStateAction<Error>) => {
         setApiError(true);


### PR DESCRIPTION
Filtering out nulls from connectors list in the UI - in case the backend response has nulls mixed in. 