### PR TITLE
Removed the Connector name field and ConnectorNameHeader from dbz con…

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/federatedModule/DataOptions.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/federatedModule/DataOptions.tsx
@@ -9,7 +9,7 @@ import {
 import { Formik } from "formik";
 import _ from "lodash";
 import React from "react";
-import { ConnectorNameTypeHeader, FormComponent } from "components";
+import { FormComponent } from "components";
 import { PropertyCategory } from "shared";
 import "./DataOption.css";
 
@@ -149,11 +149,6 @@ export const DataOptions: React.FC<IDataOptionsProps> = (props) => {
 
   return (
     <div style={{ padding: "20px" }} className={"data-options-component-page"}>
-      <ConnectorNameTypeHeader
-        connectorName={props.connectorName}
-        connectorType={props.connectorType}
-        showIcon={false}
-      />
       <Formik
         validateOnChange={true}
         enableReinitialize={true}

--- a/ui/packages/ui/src/app/pages/createConnector/federatedModule/DebeziumConfigurator.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/federatedModule/DebeziumConfigurator.tsx
@@ -283,9 +283,7 @@ export const DebeziumConfigurator: React.FC<IDebeziumConfiguratorProps> = (
               props.onChange(conf, status)
             }
             propertyDefinitions={[
-              ...formatPropertyDefinitions(
-                getBasicPropertyDefinitions(connectorProperties)
-              ),
+              ...getBasicPropertyDefinitions(connectorProperties, true),
               ...getAdvancedPropertyDefinitions(connectorProperties),
             ]}
             i18nIsRequiredText={t(

--- a/ui/packages/ui/src/app/pages/createConnector/federatedModule/Properties.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/federatedModule/Properties.tsx
@@ -3,16 +3,12 @@ import {
   ExpandableSection,
   Grid,
   GridItem,
-  Split,
-  SplitItem,
-  Text,
-  TextContent,
   Title,
 } from "@patternfly/react-core";
 import { Form, Formik } from "formik";
 import _ from "lodash";
 import React from "react";
-import { ConnectorTypeComponent, FormComponent } from "components";
+import { FormComponent } from "components";
 import { PropertyCategory } from "shared";
 import "./Properties.css";
 
@@ -53,15 +49,6 @@ const setValidation = (values: any, propertyList: ConnectorProperty[], requiredT
     }
   });
   return errors;
-};
-
-const getNameProperty = (
-  propertyList: ConnectorProperty[]
-): ConnectorProperty[] => {
-  const propertyDefinitionsCopy = _.cloneDeep(propertyList);
-  return propertyDefinitionsCopy.filter(
-    (defn: any) => defn.category === PropertyCategory.CONNECTOR_NAME
-  );
 };
 
 const getBasicProperty = (
@@ -107,9 +94,6 @@ export const Properties: React.FC<IPropertiesProps> = (props) => {
     false
   );
 
-  const [namePropertyDefinitions] = React.useState<ConnectorProperty[]>(
-    getNameProperty(props.propertyDefinitions)
-  );
   const [basicPropertyDefinitions] = React.useState<ConnectorProperty[]>(
     getBasicProperty(props.propertyDefinitions)
   );
@@ -214,47 +198,6 @@ export const Properties: React.FC<IPropertiesProps> = (props) => {
         {({ errors, touched, setFieldValue }) => (
           <Form className="pf-c-form">
             <>
-              <Grid hasGutter={true} className="connector-name-form">
-                {namePropertyDefinitions.map(
-                  (propertyDefinition: ConnectorProperty, index: any) => {
-                    return (
-                      <GridItem key={index} lg={4} sm={12}>
-                        <FormComponent
-                          propertyDefinition={propertyDefinition}
-                          propertyChange={handlePropertyChange}
-                          setFieldValue={setFieldValue}
-                          helperTextInvalid={errors[propertyDefinition.name]}
-                          invalidMsg={[]}
-                          validated={
-                            errors[propertyDefinition.name] &&
-                            touched[propertyDefinition.name] &&
-                            errors[propertyDefinition.name]
-                              ? "error"
-                              : "default"
-                          }
-                        />
-                      </GridItem>
-                    );
-                  }
-                )}
-                <GridItem key={"connType"} lg={12} sm={12}>
-                  <Split>
-                    <SplitItem>
-                      <TextContent>
-                        <Text className={"connector-type-label"}>
-                          Connector type:
-                        </Text>
-                      </TextContent>
-                    </SplitItem>
-                    <SplitItem>
-                      <ConnectorTypeComponent
-                        connectorType={props.connectorType}
-                        showIcon={false}
-                      />
-                    </SplitItem>
-                  </Split>
-                </GridItem>
-              </Grid>
               <Grid>
                 <GridItem lg={9} sm={12}>
                   <ExpandableSection

--- a/ui/packages/ui/src/app/pages/createConnector/federatedModule/RuntimeOptions.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/federatedModule/RuntimeOptions.tsx
@@ -8,7 +8,7 @@ import {
 import { Formik } from "formik";
 import _ from "lodash";
 import React from "react";
-import { ConnectorNameTypeHeader, FormComponent } from "components";
+import { FormComponent } from "components";
 import { PropertyCategory } from "shared";
 import "./RuntimeOptions.css";
 
@@ -142,11 +142,6 @@ export const RuntimeOptions: React.FC<IRuntimeOptionsProps> = (props) => {
       style={{ padding: "20px" }}
       className={"runtime-options-component-page"}
     >
-      <ConnectorNameTypeHeader
-        connectorName={props.connectorName}
-        connectorType={props.connectorType}
-        showIcon={false}
-      />
       <Formik
         validateOnChange={true}
         enableReinitialize={true}

--- a/ui/packages/ui/src/app/shared/Utils.ts
+++ b/ui/packages/ui/src/app/shared/Utils.ts
@@ -199,7 +199,8 @@ export function getConnectorTypeDescription(connType: ConnectorType): string {
  * @param propertyDefns the array of all ConnectorProperty objects
  */
 export function getBasicPropertyDefinitions(
-  propertyDefns: ConnectorProperty[]
+  propertyDefns: ConnectorProperty[],
+  isMCS?: boolean
 ): ConnectorProperty[] {
   const connProperties: ConnectorProperty[] = [];
   for (const propDefn of propertyDefns) {
@@ -218,7 +219,7 @@ export function getBasicPropertyDefinitions(
     gridWidthLg: 4,
     gridWidthSm: 12
   } as ConnectorProperty;
-  connProperties.push(connNameProperty);
+  !isMCS && connProperties.push(connNameProperty);
 
   return connProperties;
 }


### PR DESCRIPTION
- Not adding the Connector name field in `getBasicPropertyDefinitions` function incase of `MSC` true.
- Removed the Connector name field handling for federatedModule `Properties.tsx`.
- Removed the `ConnectorNameHeader` for federatedModules steps.