### PR TITLE
DBZ-3108 Filter out nulls in connector properties

### DIFF
--- a/backend/src/main/java/io/debezium/configserver/service/ConnectorIntegratorBase.java
+++ b/backend/src/main/java/io/debezium/configserver/service/ConnectorIntegratorBase.java
@@ -80,8 +80,12 @@ public abstract class ConnectorIntegratorBase implements ConnectorIntegrator {
             .collect(Collectors.toMap(connectorProperty -> connectorProperty.name, connectorProperty -> connectorProperty));
 
         // apply sorting of properties provided by {@link #allPropertiesWithAdditionalMetadata()}
-        ArrayList<ConnectorProperty> sortedProperties = allPropertiesWithAdditionalMetadata().keySet()
-                .stream().map(properties::get).collect(Collectors.toCollection(ArrayList::new));
+        ArrayList<ConnectorProperty> sortedProperties = allPropertiesWithAdditionalMetadata()
+            .keySet()
+            .stream()
+            .map(properties::get)
+            .filter(prop -> prop != null)
+            .collect(Collectors.toCollection(ArrayList::new));
 
         return new ConnectorType(
                 descriptor.id,

--- a/backend/src/main/java/io/debezium/configserver/service/mysql/MySqlConnectorIntegrator.java
+++ b/backend/src/main/java/io/debezium/configserver/service/mysql/MySqlConnectorIntegrator.java
@@ -85,7 +85,6 @@ public class MySqlConnectorIntegrator extends ConnectorIntegratorBase {
         // Data type mapping properties:
         additionalMetadata.put(MySqlConnectorConfig.EVENT_DESERIALIZATION_FAILURE_HANDLING_MODE.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR, enumArrayToList(MySqlConnectorConfig.EventProcessingFailureHandlingMode.values())));
         additionalMetadata.put(MySqlConnectorConfig.ENABLE_TIME_ADJUSTER.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR));
-        additionalMetadata.put(MySqlConnectorConfig.GTID_NEW_CHANNEL_POSITION.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR));
         additionalMetadata.put(MySqlConnectorConfig.GTID_SOURCE_FILTER_DML_EVENTS.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR));
         additionalMetadata.put(MySqlConnectorConfig.GTID_SOURCE_INCLUDES.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR));
         additionalMetadata.put(MySqlConnectorConfig.GTID_SOURCE_EXCLUDES.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR));

--- a/backend/src/test/java/io/debezium/configserver/ConnectorResourceIT.java
+++ b/backend/src/test/java/io/debezium/configserver/ConnectorResourceIT.java
@@ -47,6 +47,7 @@ public class ConnectorResourceIT {
                     equalTo(ConnectorIntegratorBase.enumArrayToList(PostgresConnectorConfig.SnapshotMode.values())))
             .body("properties.find { it.name == 'decimal.handling.mode' }.allowedValues",
                     equalTo(ConnectorIntegratorBase.enumArrayToList(PostgresConnectorConfig.DecimalHandlingMode.values())))
+            .body("properties.contains(null)", is(false))
             .body("enabled", is(true));
     }
 
@@ -63,6 +64,7 @@ public class ConnectorResourceIT {
                     equalTo(ConnectorIntegratorBase.enumArrayToList(MySqlConnectorConfig.SnapshotLockingMode.values())))
             .body("properties.find { it.name == 'snapshot.new.tables' }.allowedValues",
                     equalTo(ConnectorIntegratorBase.enumArrayToList(MySqlConnectorConfig.SnapshotNewTables.values())))
+            .body("properties.contains(null)", is(false))
             .body("enabled", is(true));
     }
 
@@ -76,6 +78,7 @@ public class ConnectorResourceIT {
             .body("properties.find { it.name == 'snapshot.mode' }.allowedValues",
                     equalTo(ConnectorIntegratorBase.enumArrayToList(MongoDbConnectorConfig.SnapshotMode.values())))
             .body("properties.find { it.name == 'field.renames' }.category", is(ConnectorProperty.Category.CONNECTOR_ADVANCED.name()))
+            .body("properties.contains(null)", is(false))
             .body("enabled", is(true));
     }
 


### PR DESCRIPTION
- Add filtering of null properties in the sort operation
- remove deprecated property from MySqlConnectorIntegrator
- adding test for null properties in ConnectorResourceIT