### PR TITLE
DBZ-4293 Corrects issue with UI step refresh

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -542,9 +542,8 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
   // Allows conversion of map keys, e.g. between dotted and underscore delimited forms
   const convertPropertyKeys = (propertyMap: Map<string, string>, searchStr: string, replaceStr: string) => {
     const convertedMap = new Map<string, string>();
-    const regEx = new RegExp(searchStr, 'g');
     for (const [key, value] of propertyMap) {
-      convertedMap.set(key.replace(regEx,replaceStr), value);
+      convertedMap.set(key.split(searchStr).join(replaceStr), value);
     }
     return convertedMap; 
   }


### PR DESCRIPTION
Corrects UI regression in the previous commit - RegEx was being used incorrectly.  After entering topic groups, proceeding to next step, then going back to topic groups step - the connector properties were not being maintained.  This commit removes the RegEx usage in favor of a different approach. 