### PR TITLE
DBZ-4119 Correct enablement of create connector steps

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/CreateConnectorComponent.tsx
@@ -289,10 +289,11 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     setShowCancelConfirmationDialog(true);
   };
 
-  const goToNext = (id: any, onNext: () => void) => {
+  const goToNext = (currentId: any, onNext: () => void) => {
     setConnectorCreateFailed(false);
-    id === 5 && setFinishStepId(RUNTIME_OPTIONS_STEP_ID);
-    setStepIdReached(stepIdReached < id ? id : stepIdReached);
+    const nextId = currentId + 1;
+    setFinishStepId(nextId);
+    setStepIdReached(stepIdReached < nextId ? nextId : stepIdReached);
     onNext();
   };
 
@@ -610,6 +611,19 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
     initPropertyValues();
   }, [connectorTypes]);
 
+  React.useEffect(() => {
+    if (connectionPropsValid === false) {
+      setStepIdReached(stepIdReached > PROPERTIES_STEP_ID ? PROPERTIES_STEP_ID : stepIdReached);
+      setFinishStepId(PROPERTIES_STEP_ID);
+      // Change in basic connection properties - resets Optional properties
+      setFilterValues(new Map<string, string>());
+      setTransformsValues(new Map<string,any>())
+      setTopicCreationPropValues(new Map<string,any>())
+      setDataOptionsPropValues(new Map<string, string>());
+      setRuntimeOptionsPropValues(new Map<string, string>());
+    }
+  }, [connectionPropsValid]);
+
   const connectorTypeStep = {
     id: CONNECTOR_TYPE_STEP_ID,
     name: CONNECTOR_TYPE_STEP,
@@ -866,7 +880,7 @@ export const CreateConnectorComponent: React.FunctionComponent<ICreateConnectorC
         />
       </>
     ),
-    canJumpTo: stepIdReached >= PROPERTIES_STEP_ID,
+    canJumpTo: connectionPropsValid,
     nextButtonText: t('finish')
   };
 


### PR DESCRIPTION
This addresses the issue raised in DBZ-4119, plus a couple other issues with the create connector wizard:
1) DBZ-4119 - When user validates connection and goes directly to 'Review', now the LH menu 'Properties' step is enabled.
2) The LH menu selection was not always correctly indicated - this PR resolves
3) If user goes back to 'Properties' step and changes a connection property, the previously visited steps are invalidated and their properties removed.  The intent here is to prevent the case where the user can connect to a completely different db, rendering previously entered optional properties invalid (filter, topic group, etc).  They will now be required to revisit and re-enter those optional properties if the connection is changed. 