### PR TITLE
DBZ-4378 Add required defaults when topic groups are defined

### DIFF
--- a/ui/packages/ui/src/app/pages/createConnector/connectorSteps/TopicCreationStep.tsx
+++ b/ui/packages/ui/src/app/pages/createConnector/connectorSteps/TopicCreationStep.tsx
@@ -143,6 +143,8 @@ export const TopicCreationStep: React.FunctionComponent<ITopicCreationStepProps>
           }
         }
       });
+      topicCreateValues.set("topic_creation_default_partitions", -1);
+      topicCreateValues.set("topic_creation_default_replication_factor", -1);
     }
     if (Object.keys(topicDefaults).length >0) {
       for (const [key, value] of Object.entries(topicDefaults)) {


### PR DESCRIPTION
Ensure that the topic group replication factor and partitions defaults are included whenever topic groups have been defined.  These two defaults are required whenever topic groups are defined, according to table 1 here - https://debezium.io/documentation/reference/configuration/topic-auto-create-config.html#default-topic-creation-group-configuration