### PR TITLE
DBZ-4540 Corrects issue with nulls in Mongo connector UI

### DIFF
--- a/backend/src/main/java/io/debezium/configserver/service/mongodb/MongoDbConnectorIntegrator.java
+++ b/backend/src/main/java/io/debezium/configserver/service/mongodb/MongoDbConnectorIntegrator.java
@@ -138,7 +138,7 @@ public class MongoDbConnectorIntegrator extends ConnectorIntegratorBase {
         }
 
         List<DataCollection> matchingTables = collections.stream()
-                .map(collectionId -> new DataCollection(collectionId.replicaSetName() + "." + collectionId.dbName(), collectionId.name()))
+                .map(collectionId -> new DataCollection( (collectionId.replicaSetName() != null ? (collectionId.replicaSetName() + ".") : "") + collectionId.dbName(), collectionId.name()))
                 .collect(Collectors.toList());
 
         return FilterValidationResult.valid(matchingTables);


### PR DESCRIPTION
Minor change to MongoDbConnectorIntegrator to eliminate null in the namespaces.

Before:
![MongoFiltersBefore](https://user-images.githubusercontent.com/1820403/149210531-9fd38991-3856-4178-bd6c-bcd14b9aedbe.png)

After:
![MongoFiltersAfter](https://user-images.githubusercontent.com/1820403/149210562-afeb8590-da5e-4bfa-99f1-52fa1b08f0b3.png)
 