### PR TITLE
DBZ-5125 Remove spatial_ref_sys table from Postgres filter tests

### DIFF
--- a/backend/src/test/java/io/debezium/configserver/CreateAndDeleteMySqlConnectorIT.java
+++ b/backend/src/test/java/io/debezium/configserver/CreateAndDeleteMySqlConnectorIT.java
@@ -72,8 +72,7 @@ public class CreateAndDeleteMySqlConnectorIT {
                 deleteMySqlConnectorName,
                 Infrastructure.getMySqlConnectorConfiguration(1)
         );
-        Infrastructure.getDebeziumContainer().ensureConnectorTaskState(
-                deleteMySqlConnectorName, 0, Connector.State.RUNNING);
+        Infrastructure.waitForConnectorTaskStatus(deleteMySqlConnectorName, 0, Connector.State.RUNNING);
 
         given()
                 .when().delete(ConnectorURIs.API_PREFIX + ConnectorURIs.MANAGE_CONNECTORS_ENDPOINT, 1, deleteMySqlConnectorName)

--- a/backend/src/test/java/io/debezium/configserver/CreateAndDeletePostgresConnectorIT.java
+++ b/backend/src/test/java/io/debezium/configserver/CreateAndDeletePostgresConnectorIT.java
@@ -12,8 +12,11 @@ import io.debezium.testing.testcontainers.Connector;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static io.restassured.RestAssured.given;
@@ -79,8 +82,17 @@ public class CreateAndDeletePostgresConnectorIT {
         Infrastructure.getDebeziumContainer().registerConnector(
                 deletePostgresConnectorName,
                 Infrastructure.getPostgresConnectorConfiguration(1));
-        Infrastructure.getDebeziumContainer().ensureConnectorTaskState(
-                deletePostgresConnectorName, 0, Connector.State.RUNNING);
+
+        // It is possible the connector has not fully started and the tasks array returns
+        // no running tasks, leading to a potential NPE with this call.
+        Awaitility.await()
+                .atMost(60, TimeUnit.SECONDS)
+                .ignoreException(NullPointerException.class)
+                .until(() -> {
+                    Infrastructure.getDebeziumContainer().ensureConnectorTaskState(
+                            deletePostgresConnectorName, 0, Connector.State.RUNNING);
+                    return true;
+                });
 
         given()
                 .when().delete(ConnectorURIs.API_PREFIX + ConnectorURIs.MANAGE_CONNECTORS_ENDPOINT, 1, deletePostgresConnectorName)

--- a/backend/src/test/java/io/debezium/configserver/CreateAndDeletePostgresConnectorIT.java
+++ b/backend/src/test/java/io/debezium/configserver/CreateAndDeletePostgresConnectorIT.java
@@ -12,11 +12,8 @@ import io.debezium.testing.testcontainers.Connector;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.TestProfile;
 import io.restassured.http.ContentType;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static io.restassured.RestAssured.given;
@@ -85,14 +82,7 @@ public class CreateAndDeletePostgresConnectorIT {
 
         // It is possible the connector has not fully started and the tasks array returns
         // no running tasks, leading to a potential NPE with this call.
-        Awaitility.await()
-                .atMost(60, TimeUnit.SECONDS)
-                .ignoreException(NullPointerException.class)
-                .until(() -> {
-                    Infrastructure.getDebeziumContainer().ensureConnectorTaskState(
-                            deletePostgresConnectorName, 0, Connector.State.RUNNING);
-                    return true;
-                });
+        Infrastructure.waitForConnectorTaskStatus(deletePostgresConnectorName, 0, Connector.State.RUNNING);
 
         given()
                 .when().delete(ConnectorURIs.API_PREFIX + ConnectorURIs.MANAGE_CONNECTORS_ENDPOINT, 1, deletePostgresConnectorName)

--- a/backend/src/test/java/io/debezium/configserver/ListPostgresConnectorIT.java
+++ b/backend/src/test/java/io/debezium/configserver/ListPostgresConnectorIT.java
@@ -50,11 +50,15 @@ public class ListPostgresConnectorIT {
         Infrastructure.getDebeziumContainer().registerConnector(
                 runningConnectorName,
                 Infrastructure.getPostgresConnectorConfiguration(1));
+        Infrastructure.waitForConnectorTaskStatus(runningConnectorName, 0, Connector.State.RUNNING);
+
         Infrastructure.getDebeziumContainer().registerConnector(
                 pausedConnectorName,
                 Infrastructure.getPostgresConnectorConfiguration(2)
                         .with("table.include.list", ".*"));
         Infrastructure.getDebeziumContainer().pauseConnector(pausedConnectorName);
+        Infrastructure.waitForConnectorTaskStatus(pausedConnectorName, 0, Connector.State.PAUSED);
+
         // TODO When a stable version with DBZ-4517 is released and used the parameter name should be
         // changed to 'slot.max.retries'
         Infrastructure.getDebeziumContainer().registerConnector(
@@ -62,7 +66,7 @@ public class ListPostgresConnectorIT {
                 Infrastructure.getPostgresConnectorConfiguration(1)
                         .with("database.server.name", "dbserver1_failing")
                         .with("database.slot.max.retries", "0"));
-        Infrastructure.getDebeziumContainer().ensureConnectorTaskState(failedConnectorName, 0, Connector.State.FAILED);
+        Infrastructure.waitForConnectorTaskStatus(failedConnectorName, 0, Connector.State.FAILED);
 
         given()
                 .when().get(ConnectorURIs.API_PREFIX + ConnectorURIs.LIST_CONNECTORS_ENDPOINT, "1")

--- a/backend/src/test/java/io/debezium/configserver/ValidatePostgresFiltersIT.java
+++ b/backend/src/test/java/io/debezium/configserver/ValidatePostgresFiltersIT.java
@@ -40,10 +40,9 @@ public class ValidatePostgresFiltersIT {
             .statusCode(200)
             .assertThat().body("status", equalTo("VALID"))
                 .body("propertyValidationResults.size()", is(0))
-                .body("matchedCollections.size()", is(6))
+                .body("matchedCollections.size()", is(5))
                 .body("matchedCollections",
                     hasItems(
-                        Map.of("namespace", "inventory", "name", "spatial_ref_sys"),
                         Map.of("namespace", "inventory", "name", "geom"),
                         Map.of("namespace", "inventory", "name", "products_on_hand"),
                         Map.of("namespace", "inventory", "name", "customers"),
@@ -90,10 +89,9 @@ public class ValidatePostgresFiltersIT {
             .statusCode(200)
             .assertThat().body("status", equalTo("VALID"))
                 .body("propertyValidationResults.size()", is(0))
-                .body("matchedCollections.size()", is(6))
+                .body("matchedCollections.size()", is(5))
                 .body("matchedCollections",
                     hasItems(
-                        Map.of("namespace", "inventory", "name", "spatial_ref_sys"),
                         Map.of("namespace", "inventory", "name", "geom"),
                         Map.of("namespace", "inventory", "name", "products_on_hand"),
                         Map.of("namespace", "inventory", "name", "customers"),


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5125

- [x] Fixes failures in `ValidatePostgresFiltersIT` test in reference with https://issues.redhat.com/browse/DBZ-4814
- [x] Fix NPE race condition in several tests.