### PR TITLE
DBZ-5437 Move to Debezium 2.0.0.Alpha3 as baseline

### DIFF
--- a/.github/workflows/backend-testing.yml
+++ b/.github/workflows/backend-testing.yml
@@ -22,10 +22,11 @@ jobs:
     steps:
       - name: Checkout Debezium UI
         uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 11
+          distribution: 'temurin'
+          java-version: 17
       - name: Cache local Maven repository
         uses: actions/cache@v2
         with:

--- a/.github/workflows/end-to-end-testing.yml
+++ b/.github/workflows/end-to-end-testing.yml
@@ -26,17 +26,17 @@ jobs:
 
     services:
       dbzui-zookeeper:
-        image: debezium/zookeeper:1.6
+        image: debezium/zookeeper:1.9
 
       dbzui-kafka:
-        image: debezium/kafka:1.6
+        image: debezium/kafka:1.9
         ports:
           - 9092:9092
         env: 
           ZOOKEEPER_CONNECT: dbzui-zookeeper:2181
 
       dbzui-postgres:
-        image: debezium/example-postgres:1.6
+        image: debezium/example-postgres:1.9
         ports:
           - 65432:5432
         env: 

--- a/.github/workflows/end-to-end-testing.yml
+++ b/.github/workflows/end-to-end-testing.yml
@@ -26,17 +26,17 @@ jobs:
 
     services:
       dbzui-zookeeper:
-        image: debezium/zookeeper:1.9
+        image: debezium/zookeeper:2.0
 
       dbzui-kafka:
-        image: debezium/kafka:1.9
+        image: debezium/kafka:2.0
         ports:
           - 9092:9092
         env: 
           ZOOKEEPER_CONNECT: dbzui-zookeeper:2181
 
       dbzui-postgres:
-        image: debezium/example-postgres:1.9
+        image: debezium/example-postgres:2.0
         ports:
           - 65432:5432
         env: 

--- a/backend/src/main/java/io/debezium/configserver/service/mongodb/MongoDbConnectorIntegrator.java
+++ b/backend/src/main/java/io/debezium/configserver/service/mongodb/MongoDbConnectorIntegrator.java
@@ -95,7 +95,6 @@ public class MongoDbConnectorIntegrator extends ConnectorIntegratorBase {
         additionalMetadata.put(MongoDbConnectorConfig.MAX_QUEUE_SIZE.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(MongoDbConnectorConfig.POLL_INTERVAL_MS.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(MongoDbConnectorConfig.RETRIABLE_RESTART_WAIT.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
-        additionalMetadata.put(MongoDbConnectorConfig.SOURCE_STRUCT_MAKER_VERSION.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
 
         MONGODB_PROPERTIES =  Collections.unmodifiableMap(additionalMetadata);
     }

--- a/backend/src/main/java/io/debezium/configserver/service/mysql/MySqlConnectorIntegrator.java
+++ b/backend/src/main/java/io/debezium/configserver/service/mysql/MySqlConnectorIntegrator.java
@@ -119,7 +119,6 @@ public class MySqlConnectorIntegrator extends ConnectorIntegratorBase {
         additionalMetadata.put(MySqlConnectorConfig.MAX_BATCH_SIZE.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(MySqlConnectorConfig.MAX_QUEUE_SIZE.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(MySqlConnectorConfig.POLL_INTERVAL_MS.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
-        additionalMetadata.put(MySqlConnectorConfig.SOURCE_STRUCT_MAKER_VERSION.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
 
         MYSQL_PROPERTIES = Collections.unmodifiableMap(additionalMetadata);
     }

--- a/backend/src/main/java/io/debezium/configserver/service/postgres/PostgresConnectorIntegrator.java
+++ b/backend/src/main/java/io/debezium/configserver/service/postgres/PostgresConnectorIntegrator.java
@@ -113,7 +113,7 @@ public class PostgresConnectorIntegrator extends ConnectorIntegratorBase {
         additionalMetadata.put(PostgresConnectorConfig.PROPAGATE_COLUMN_SOURCE_TYPE.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR_ADVANCED));
         additionalMetadata.put(PostgresConnectorConfig.MSG_KEY_COLUMNS.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR_ADVANCED));
         additionalMetadata.put(PostgresConnectorConfig.INCLUDE_UNKNOWN_DATATYPES.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR_ADVANCED));
-        additionalMetadata.put(PostgresConnectorConfig.TOASTED_VALUE_PLACEHOLDER.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR_ADVANCED));
+        additionalMetadata.put(PostgresConnectorConfig.UNAVAILABLE_VALUE_PLACEHOLDER.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR_ADVANCED));
         additionalMetadata.put(PostgresConnectorConfig.PROVIDE_TRANSACTION_METADATA.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR_ADVANCED));
         additionalMetadata.put(PostgresConnectorConfig.SANITIZE_FIELD_NAMES.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.CONNECTOR_ADVANCED));
 
@@ -124,7 +124,6 @@ public class PostgresConnectorIntegrator extends ConnectorIntegratorBase {
         additionalMetadata.put(PostgresConnectorConfig.MAX_QUEUE_SIZE.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(PostgresConnectorConfig.POLL_INTERVAL_MS.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(PostgresConnectorConfig.RETRIABLE_RESTART_WAIT.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
-        additionalMetadata.put(PostgresConnectorConfig.SOURCE_STRUCT_MAKER_VERSION.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
 
         POSTGRES_PROPERTIES = Collections.unmodifiableMap(additionalMetadata);
     }

--- a/backend/src/main/java/io/debezium/configserver/service/postgres/PostgresConnectorIntegrator.java
+++ b/backend/src/main/java/io/debezium/configserver/service/postgres/PostgresConnectorIntegrator.java
@@ -138,7 +138,7 @@ public class PostgresConnectorIntegrator extends ConnectorIntegratorBase {
 
         PostgresConnectorConfig config = new PostgresConnectorConfig(Configuration.from(properties));
 
-        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig())) {
+        try (PostgresConnection connection = new PostgresConnection(config.getJdbcConfig(), PostgresConnection.CONNECTION_GENERAL)) {
             Set<TableId> tables;
             try {
                 tables = connection.readTableNames(config.databaseName(), null, null, new String[]{ "TABLE" });

--- a/backend/src/main/java/io/debezium/configserver/service/sqlserver/SqlServerConnectorIntegrator.java
+++ b/backend/src/main/java/io/debezium/configserver/service/sqlserver/SqlServerConnectorIntegrator.java
@@ -104,7 +104,6 @@ public class SqlServerConnectorIntegrator extends ConnectorIntegratorBase {
         additionalMetadata.put(SqlServerConnectorConfig.MAX_QUEUE_SIZE.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(SqlServerConnectorConfig.POLL_INTERVAL_MS.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(SqlServerConnectorConfig.RETRIABLE_RESTART_WAIT.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
-        additionalMetadata.put(SqlServerConnectorConfig.SOURCE_STRUCT_MAKER_VERSION.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
         additionalMetadata.put(SqlServerConnectorConfig.SIGNAL_DATA_COLLECTION.name(), new AdditionalPropertyMetadata(false, ConnectorProperty.Category.ADVANCED));
 
         SQLSERVER_PROPERTIES = Collections.unmodifiableMap(additionalMetadata);

--- a/backend/src/test/java/io/debezium/configserver/CreateAndDeleteSqlSeverConnectorIT.java
+++ b/backend/src/test/java/io/debezium/configserver/CreateAndDeleteSqlSeverConnectorIT.java
@@ -46,7 +46,7 @@ public class CreateAndDeleteSqlSeverConnectorIT {
     @Test
     public void testSqlServerCreateConnectorEndpoint() {
         ConnectorConfiguration config = Infrastructure.getSqlServerConnectorConfiguration(1)
-                .with("database.dbname", "testdb");
+                .with("database.names", "testdb");
 
         Connector connector = Connector.from("my-sqlserver-connector", config);
 
@@ -74,7 +74,7 @@ public class CreateAndDeleteSqlSeverConnectorIT {
     @Test
     public void testSqlServerDeleteConnectorSuccessful() {
         ConnectorConfiguration config = Infrastructure.getSqlServerConnectorConfiguration(1)
-                .with("database.dbname", "testdb");
+                .with("database.names", "testdb");
 
         final var deleteSqlServerConnectorName = "delete-connector-sqlsever";
         Infrastructure.getDebeziumContainer().deleteAllConnectors();

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,11 @@
 
   <properties>
     <revision>1.9.0-SNAPSHOT</revision>
-    <debezium.base.version>${revision}</debezium.base.version>
+    <!--
+    For now lets explicitly lock into Debezium 1.9.5
+    Do not forget to adjust .github/workflows/end-to-end-testing.yaml to align with this version
+    -->
+    <debezium.base.version>1.9.5.Final</debezium.base.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>

--- a/pom.xml
+++ b/pom.xml
@@ -14,10 +14,10 @@
   <properties>
     <revision>1.9.0-SNAPSHOT</revision>
     <!--
-    For now lets explicitly lock into Debezium 1.9.5
+    For now lets explicitly lock into a specific Debezium version
     Do not forget to adjust .github/workflows/end-to-end-testing.yaml to align with this version
     -->
-    <debezium.base.version>1.9.5.Final</debezium.base.version>
+    <debezium.base.version>2.0.0.Alpha3</debezium.base.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5437

This addresses two key issues:
* The first is that in Debezium 1.9.3.Final, the signature for the `PostgresConnection` changed and the usage was not updated in the UI repository.  Commit f9722be addresses this by aligning the signature usage.
* The integration tests use `debezium/connect:nightly` which is based on Debezium 2.0 at this point.  As a result the usage of the `database.dbname` has been removed in favor of `database.names`.  I've updated the tests to reflect this change.

This highlights one point of discussion as it relates to the version of Debezium that this project is based upon.  In the POM, it currently references `1.9.0-SNAPSHOT` and yet our tests are explicitly testing against the nightly container build that is based upon 2.0.  

In this PR I have forwarded the Debezium dependency to 2.0.0.Alpha3 explicitly.  I have left the POM version reference still as 1.9.0-SNAPSHOT until we agree on whether we should advance this or not.  

