### PR TITLE
DBZ-5613 Wait before SQL server container is considered as started

### DIFF
--- a/backend/src/test/java/io/debezium/configserver/util/Infrastructure.java
+++ b/backend/src/test/java/io/debezium/configserver/util/Infrastructure.java
@@ -23,6 +23,7 @@ import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.startupcheck.MinimumDurationRunningStartupCheckStrategy;
 import org.testcontainers.lifecycle.Startables;
 import org.testcontainers.utility.DockerImageName;
 
@@ -76,6 +77,7 @@ public class Infrastructure {
                     .withEnv("MSSQL_PID", "Standard")
                     .withEnv("MSSQL_AGENT_ENABLED", "true")
                     .withPassword("Password!")
+                    .withStartupCheckStrategy(new MinimumDurationRunningStartupCheckStrategy(Duration.ofSeconds(5)))
                     .withInitScript("/initialize-sqlserver-database.sql")
                     .acceptLicense();
 


### PR DESCRIPTION
We execute init script once the container is started, but started container may not be initialized yet and e.g. setting CDC for tables may fail with:

    Cannot perform this operation while SQLServerAgent is starting. Try again later.

This happens especially in CI where the machines are slower. Add startup strategy to wait for 5 seconds until container is considered as started.

https://issues.redhat.com/browse/DBZ-5613