### PR TITLE
DBZ-5664 Fix ValidatePostgresConnectionIT.testInvalidPostgresConnecti…

### DIFF
--- a/backend/src/test/java/io/debezium/configserver/ValidatePostgresConnectionIT.java
+++ b/backend/src/test/java/io/debezium/configserver/ValidatePostgresConnectionIT.java
@@ -72,7 +72,7 @@ public class ValidatePostgresConnectionIT {
             .statusCode(200)
             .assertThat().body("status", equalTo("INVALID"))
                 .body("genericValidationResults.size()", is(0))
-                .body("propertyValidationResults.size()", is(3))
+                .body("propertyValidationResults.size()", is(4))
                 .body("propertyValidationResults",
                     hasItems(
                         Map.of("property", "database.user", "message", "The 'database.user' value is invalid: A value is required"),


### PR DESCRIPTION
…on test

After removing default value for `topic.prefix` there is one more error message in the response.

https://issues.redhat.com/browse/DBZ-5664