### PR TITLE
DBZ-5667 Cleanup UI tests after removing defaul topic.prefix

### DIFF
--- a/ui/cypress/integration/connectors.spec.ts
+++ b/ui/cypress/integration/connectors.spec.ts
@@ -27,7 +27,7 @@ describe("Connectors page", () => {
       "dbz-pg-conn"
     );
     cy.get('input[name="topic&prefix"]', { timeout: 50000 }).type(
-      "{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}{backspace}fulfillment"
+      "fulfillment"
     );
     cy.get('input[name="database&hostname"]', { timeout: 50000 }).type(
       "dbzui-postgres"


### PR DESCRIPTION
Backspaces don't break the tests, but clutter the test code, so remove it once it's not needed.

https://issues.redhat.com/browse/DBZ-5667