### PR TITLE
DBZ-5865 Add connector.displayName and connector.id to Config endpoint

### DIFF
--- a/backend/src/test/java/io/debezium/configserver/ConnectorResourceIT.java
+++ b/backend/src/test/java/io/debezium/configserver/ConnectorResourceIT.java
@@ -126,7 +126,9 @@ public class ConnectorResourceIT {
                 .body("'connector.class'", equalTo("io.debezium.connector.postgresql.PostgresConnector"))
                 .body("'topic.prefix'", equalTo("dbserver1"))
                 .body("'database.dbname'", equalTo("test"))
-                .body("'database.user'", equalTo("test"));
+                .body("'database.user'", equalTo("test"))
+                .body("'connector.displayName'", equalTo("PostgreSQL"))
+                .body("'connector.id'", equalTo("postgres"));
     }
 
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/DBZ-5865

This adds the `connector.displayName` and `connector.id` to the config endpoint payload.  
@uidoyen let me know if this needs to be adjusted.