### PR TITLE
fix path for Topic Creation Enabled endpoint of REST extension

### DIFF
--- a/backend/src/main/java/io/debezium/configserver/rest/client/KafkaConnectClient.java
+++ b/backend/src/main/java/io/debezium/configserver/rest/client/KafkaConnectClient.java
@@ -90,7 +90,7 @@ public interface KafkaConnectClient {
     List<TransformsInfo> listTransforms() throws ProcessingException, IOException;
 
     @GET
-    @Path("/debezium/topic-creation")
+    @Path("/debezium/topic-creation-enabled")
     @Produces("application/json")
     Boolean isTopicCreationEnabled() throws ProcessingException, IOException;
 


### PR DESCRIPTION
A recent change (Sep/23) on Debezium REST extension has changed the Topic Creation Enabled endpoint from /debezium/topic-creation to /debezium/topic-creation-enabled. That change wasn't reflected on the UI backend.
See this [commit **DBZ-4395 Add connector specific Debezium Connect REST Extension/s and…**](https://github.com/debezium/debezium/commit/32161c98742357b89884634aa1210d7407b471ed)